### PR TITLE
Remove preferences for unsupported plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Full featured Python Language Server plugin (implements [PyLS](https://github.com/python-lsp/python-lsp-server)) for Nova, supports Jedi Autocomplete, PyFlakes, PyLint, YAPF, Rope, McCabe, PyDoc and CodeStyles.
 
-Also supports all the Python Language Server plugins → `mypy`, `isort` and `black`
+Also supports the Python Language Server plugin `mypy`.
 
 ## Working Features
 
@@ -32,11 +32,6 @@ pip3 install 'python-lsp-server[all]'
 3. (Optional) Install Python Language Server plugins and enable them from settings:
 
 - `mypy` plugin: `pip3 install pyls-mypy`
-
-- `isort` plugin: `pip3 install pyls-isort`
-
-- `black` plugin: `pip3 install pyls-black`
-
 
 ## Features
 

--- a/Scripts/main.js
+++ b/Scripts/main.js
@@ -221,12 +221,6 @@ function getSettings() {
                     "pyls_mypy": {
                         "enabled": getPreference('pyls.plugins.pyls_mypy.enabled'),
                         "live_mode": getPreference('pyls.plugins.pyls_mypy.live_mode')
-                    },
-                    "pyls_black": {
-                        "enabled": getPreference('pyls.plugins.pyls_black.enabled')
-                    },
-                    "pyls_isort": {
-                        "enabled": getPreference('pyls.plugins.pyls_isort.enabled')
                     }
                 }
                 
@@ -291,9 +285,7 @@ class PythonLanguageServer {
             'pyls.rope.ropeFolder',
             'pyls.rope.extensionModules', 
             'pyls.plugins.pyls_mypy.enabled',
-            'pyls.plugins.pyls_mypy.live_mode',
-            'pyls.plugins.pyls_isort.enabled',
-            'pyls.plugins.pyls_black.enabled'
+            'pyls.plugins.pyls_mypy.live_mode'
         ];
         for (var i of keys) {
             nova.config.onDidChange(i, async function(newValue, oldValue) {

--- a/extension.json
+++ b/extension.json
@@ -489,35 +489,7 @@
                             "description": "Enable or disable Live Mode"
                         }
                     ]
-                },
-                {
-                "title": "iSort",
-                "type": "section",
-                "description": "Enable after installing using → pip3 install pyls-isort",
-                "key": "works.creativecode.pyls.isortPluginSec",
-                "children": [
-                    {
-                        
-                        "key": "pyls.plugins.pyls_isort.enabled",
-                        "type": "boolean",
-                        "title": "Enable iSort",
-                        "default": false,
-                        "description": "Enable or disable the iSort PyLS plugin."
-                    }]},
-                {
-                "title": "Black",
-                "type": "section",
-                "description": "Enable after installing using → pip3 install pyls-black",
-                "key": "works.creativecode.mypy.mypyPluginSec",
-                "children": [
-                    {
-                        
-                        "key": "pyls.plugins.pyls_black.enabled",
-                        "type": "boolean",
-                        "title": "Enable Black",
-                        "default": false,
-                        "description": "Enable or disable the Black PyLS plugin."
-                    }]}
+                }
             ]
         }
     ]


### PR DESCRIPTION
It is my understanding that currently Nova does not support the [`textDocument/formatting`](https://microsoft.github.io/language-server-protocol/specifications/specification-3-15/#textDocument_formatting) and [`textDocument/rangeFormatting`](https://microsoft.github.io/language-server-protocol/specifications/specification-3-15/#textDocument_rangeFormatting) LSP commands : https://docs.nova.app/api-reference/language-client/#supported-language-server-features

From what I could gather, both the pyls-black and pyls-isort LSP plugins rely on these commands to edit the file. So until Nova supports more of the LSP spec, we should not "advertise" support for these plugins.

_Please double-check my assumptions. That's what I understood of the state of things after digging around trying to make these plugins work, but I could be wrong. If anyone had any success making these work, please don't hesitate to correct me!_ ☺️