### PR TITLE
Fix broken main.js after merge of 'pylsNamespace' branch

### DIFF
--- a/Scripts/main.js
+++ b/Scripts/main.js
@@ -117,10 +117,10 @@ function getSettingsPyLSNamespace() {
 
 // Get and return the preferences dictionary
 function getSettings() {
-    return {
     const pylsNamespace = getSettingsPyLSNamespace()
+    return {
         settings: {
-            pylsNamespace: {
+            [pylsNamespace]: {
                 "env": {},
                 "configurationSources": [
                     getPreference('pyls.configurationSources')


### PR DESCRIPTION
So. I'm not sure why / how, but merging #18 resulted in a invalid  (as in "not executable JavaScript") main.js file :/

Sorry I didn't catch that sooner, I was using my fork all this time.

This fixes the merge, and also fixes the use of the `pylsNamespace` variable as a key in the settings objects (it was interpreted as a string before).